### PR TITLE
SCRUM-63 ANULAR ICONOS EN LOS TEXTFIELD

### DIFF
--- a/auth/src/main/java/com/refactoringlife/auth/features/login/presentation/composables/UnderLineTextField.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/login/presentation/composables/UnderLineTextField.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import com.refactoringlife.auth.R
 import com.refactoringlife.auth.features.login.presentation.theme.GrayLight
 import com.refactoringlife.auth.features.login.presentation.theme.HuellaErrorRed
+import com.refactoringlife.core.common.utils.isAllowedInput
 
 @Composable
 fun UnderlineTextField(
@@ -53,7 +54,11 @@ fun UnderlineTextField(
         Box {
             BasicTextField(
                 value = value,
-                onValueChange = onValueChange,
+                onValueChange = {
+                    if (it.isAllowedInput()){
+                        onValueChange(it)
+                    }
+                },
                 singleLine = true,
                 visualTransformation = visualTransformation,
                 textStyle = androidx.compose.ui.text.TextStyle(

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/TextFieldRegister.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/TextFieldRegister.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import com.refactoringlife.auth.features.register.presentation.util.Constants
+import com.refactoringlife.core.common.utils.isAllowedInput
 
 @Composable
 fun TextFieldCustom(
@@ -34,7 +35,11 @@ fun TextFieldCustom(
     ) {
     OutlinedTextField(
         value = value,
-        onValueChange = onValueChange,
+        onValueChange = {
+            if (it.isAllowedInput()){
+                onValueChange(it)
+            }
+        },
         singleLine = true,
         visualTransformation = if (isPassword && !showPassword) {
             PasswordVisualTransformation()

--- a/core/src/main/java/com/refactoringlife/core/common/utils/ValidationExtensions.kt
+++ b/core/src/main/java/com/refactoringlife/core/common/utils/ValidationExtensions.kt
@@ -15,3 +15,7 @@ fun String?.isValidPassword(): Boolean {
 fun String?.isPasswordMatch(confirmPassword: String?): Boolean {
     return this == confirmPassword && !this.isNullOrBlank()
 }
+fun String.isAllowedInput(): Boolean {
+    val regex = Regex("[-a-zA-Z0-9\\s.,!?;:\"'()&@$#%*+]*")
+    return this.matches(regex)
+}


### PR DESCRIPTION
# 📌 Título del PR
Sacar iconos de los TextField

---

## 📋 Descripción
En todos los textfield no se podra ingresar iconos/emojis

---

## ✅ Evidencia

https://github.com/user-attachments/assets/6708e06a-592c-4b11-a58a-723c6dd24db1



---

## 🔍 Checklist
- [x] Código probado localmente
- [x] Compila sin errores
- [x] Pruebas de regresion
- [ ] Tests actualizados 

---

## 🔗 SCRUM-63
- 