### PR TITLE
fix(register): phone keyboard and image shape

### DIFF
--- a/auth/src/main/AndroidManifest.xml
+++ b/auth/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <application>
         <activity
             android:name=".features.activity.presenter.AuthActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:screenOrientation="portrait"
             android:launchMode="singleTop">

--- a/auth/src/main/java/com/refactoringlife/auth/features/activity/presenter/AuthActivity.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/activity/presenter/AuthActivity.kt
@@ -20,7 +20,6 @@ import com.refactoringlife.core.common.utils.navigateToDeeplink
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import androidx.core.view.WindowCompat
 
 @AndroidEntryPoint
 class AuthActivity : BaseActivity(R.id.fragment_container) {

--- a/auth/src/main/java/com/refactoringlife/auth/features/activity/presenter/AuthActivity.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/activity/presenter/AuthActivity.kt
@@ -20,6 +20,7 @@ import com.refactoringlife.core.common.utils.navigateToDeeplink
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import androidx.core.view.WindowCompat
 
 @AndroidEntryPoint
 class AuthActivity : BaseActivity(R.id.fragment_container) {

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/BaseRegister.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/BaseRegister.kt
@@ -9,12 +9,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -22,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -89,16 +91,23 @@ fun BaseRegister(
         Spacer(modifier = Modifier.height(16.dp))
         Surface(
             modifier = Modifier.size(120.dp),
-            shape = RoundedCornerShape(20.dp),
+            shape = CircleShape,
             color = Color.White
         ) {
             Image(
                 painter = painter,
-                contentDescription = "logo",
+                contentDescription = "profile image",
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .size(110.dp)
-                    .clickable { pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)) }
+                    .fillMaxSize()
+                    .clip(CircleShape)
+                    .clickable{
+                        pickMedia.launch(
+                            PickVisualMediaRequest(
+                                ActivityResultContracts.PickVisualMedia.ImageOnly)
+                        )
+                    }
+
             )
         }
         Spacer(modifier = Modifier.height(16.dp))

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/BaseRegister.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/BaseRegister.kt
@@ -65,8 +65,8 @@ fun BaseRegister(
             .fillMaxWidth()
             .fillMaxHeight()
             .background(Color.White)
-            .verticalScroll(scroll)
-            .imePadding(),
+            .imePadding()
+            .verticalScroll(scroll),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         BackIcon(
@@ -79,7 +79,6 @@ fun BaseRegister(
                 .padding(start = 16.dp, top = 16.dp)
         )
         Spacer(modifier = Modifier.height(30.dp))
-
         TextCustom(
             title = stringResource(id = R.string.register_title_),
             fontSize = 26.sp,
@@ -89,7 +88,6 @@ fun BaseRegister(
             modifier = Modifier
                 .fillMaxWidth()
         )
-
         Spacer(modifier = Modifier.height(16.dp))
         Surface(
             modifier = Modifier.size(120.dp),
@@ -109,7 +107,6 @@ fun BaseRegister(
                                 ActivityResultContracts.PickVisualMedia.ImageOnly)
                         )
                     }
-
             )
         }
         Spacer(modifier = Modifier.height(16.dp))

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/BaseRegister.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/BaseRegister.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -64,7 +65,8 @@ fun BaseRegister(
             .fillMaxWidth()
             .fillMaxHeight()
             .background(Color.White)
-            .verticalScroll(state = scroll),
+            .verticalScroll(scroll)
+            .imePadding(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         BackIcon(

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/RegisterView.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/RegisterView.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.Red
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -94,7 +95,9 @@ fun RegisterView(
                 placeholderText = stringResource(id = R.string.register_phone),
                 placeholderFontSize = 16.sp,
                 placeHolderColor = grayLight,
-                modifier = Modifier
+                modifier = Modifier,
+                keyboardType = KeyboardType.Number,
+                onlyNumbers = true
             )
             Spacer(modifier = Modifier.height(16.dp))
             TextFieldCustom(

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/TextFieldRegister.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/TextFieldRegister.kt
@@ -39,14 +39,13 @@ fun TextFieldCustom(
     OutlinedTextField(
         value = value,
         onValueChange = { newValue ->
-            if (onlyNumbers) {
-                if (newValue.all { it.isDigit() }) {
-                    onValueChange(newValue)
-                }
-            } else {
-                if (newValue.isAllowedInput()) {
-                    onValueChange(newValue)
-                }
+            val isValid = when {
+                onlyNumbers -> newValue.all { it.isDigit() }
+                else -> newValue.isAllowedInput()
+            }
+
+            if (isValid) {
+                onValueChange(newValue)
             }
         },
         singleLine = true,

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/TextFieldRegister.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/content/TextFieldRegister.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -14,6 +15,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.TextUnit
@@ -31,16 +33,26 @@ fun TextFieldCustom(
     placeHolderColor: Color,
     isPassword: Boolean = false,
     showPassword: Boolean = false,
-
-    ) {
+    keyboardType: KeyboardType = KeyboardType.Text,
+    onlyNumbers: Boolean = false
+) {
     OutlinedTextField(
         value = value,
-        onValueChange = {
-            if (it.isAllowedInput()){
-                onValueChange(it)
+        onValueChange = { newValue ->
+            if (onlyNumbers) {
+                if (newValue.all { it.isDigit() }) {
+                    onValueChange(newValue)
+                }
+            } else {
+                if (newValue.isAllowedInput()) {
+                    onValueChange(newValue)
+                }
             }
         },
         singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = keyboardType
+        ),
         visualTransformation = if (isPassword && !showPassword) {
             PasswordVisualTransformation()
         } else {

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/fragment/RegisterFragment.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/fragment/RegisterFragment.kt
@@ -37,7 +37,6 @@ class RegisterFragment : Fragment() {
                 success = {
                     shareViewModel.goToAdoption()
                 }
-
             )
         }
         return composeView

--- a/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/fragment/RegisterFragment.kt
+++ b/auth/src/main/java/com/refactoringlife/auth/features/register/presentation/fragment/RegisterFragment.kt
@@ -10,7 +10,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.refactoringlife.auth.core.share.ShareViewModel
-import com.refactoringlife.auth.features.login.presentation.fragment.LoginFragment
 import com.refactoringlife.auth.features.register.presentation.screen.RegisterScreen
 import com.refactoringlife.auth.features.register.presentation.viewmodel.RegisterViewModel
 import kotlin.getValue


### PR DESCRIPTION
# 📌 Fix register image and phone input
This PR fixes UI issues on the Register screen to better match the Figma design.

---

## 📋 Descripción
Changes included:
- Profile image now displays as a circular avatar
- Phone input uses a numeric keyboard instead of alphanumeric

---

## ✅ Evidencia
before
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/37ea5363-ae1d-48c9-ab67-892469e65943" />
after
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/a1e466bf-0761-4d22-beaa-8a3959872888" />



---

## 🔍 Checklist
- [Ok ] Código probado localmente
- [Ok ] Compila sin errores
- [ ] Pruebas de regresion
- [ ] Tests actualizados 

---

## 🔗 Ticket relacionado
-  Custom Register